### PR TITLE
Switch to spaced-comment rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,8 +246,7 @@ module.exports = {
     "space-before-function-paren": [2, "always"],
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
-    "spaced-line-comment": 2,
+    "spaced-comment": [2, "always"],
 
   }
 }
-


### PR DESCRIPTION
Previously used rule space-line-comment has been deprecated and generated errors.

https://github.com/eslint/eslint/blob/master/docs/rules/spaced-line-comment.md
